### PR TITLE
fix: ClassCastException on file with videotrack

### DIFF
--- a/src/de/wiest_lukas/lib/AACPlayer.java
+++ b/src/de/wiest_lukas/lib/AACPlayer.java
@@ -13,6 +13,7 @@ import javax.sound.sampled.*;
 import net.sourceforge.jaad.aac.Decoder;
 import net.sourceforge.jaad.aac.SampleBuffer;
 import net.sourceforge.jaad.mp4.MP4Container;
+import net.sourceforge.jaad.mp4.MP4Exception;
 import net.sourceforge.jaad.mp4.api.*;
 
 /**
@@ -113,7 +114,14 @@ public class AACPlayer
                 {
                     cont    = new MP4Container(new RandomAccessFile(files[currentTrack], "r")); // open titel with random access
                     movie   = cont.getMovie();                          // get content from container,
-                    track   = (AudioTrack) movie.getTracks().get(0);    // grab first track and set the audioformat
+                    track = null;
+                    for (Track elem : movie.getTracks()) {
+                        if(elem instanceof AudioTrack) {
+                            track   = (AudioTrack) elem; // grab audio track and set the audioformat
+                        }
+                    }
+                    if(track == null)
+                        throw new MP4Exception("No audiotracks");
                     af      = new AudioFormat(track.getSampleRate(), track.getSampleSize(), track.getChannelCount(), true, true);
                     line    = AudioSystem.getSourceDataLine(af);        // get a DataLine from the AudioSystem
                     line.open();                                        // open and


### PR DESCRIPTION
Now checks all tracks for an audiotrack, take last one and use that instead of always first track, which might be a videotrack